### PR TITLE
fix reload goroutine leak and close after flush

### DIFF
--- a/backend/file.go
+++ b/backend/file.go
@@ -60,7 +60,7 @@ func (fb *FileBackend) Write(p []byte) (err error) {
 	defer fb.lock.Unlock()
 
 	var length uint32 = uint32(len(p))
-	binary.Write(fb.producer, binary.BigEndian, length)
+	err = binary.Write(fb.producer, binary.BigEndian, length)
 	if err != nil {
 		log.Print("write length error: ", err)
 		return


### PR DESCRIPTION
1、修复reload导致的goroutine泄漏
2、修复close操作，必须等待flush完成才close