### PR TITLE
Feature/write params

### DIFF
--- a/backend/backends.go
+++ b/backend/backends.go
@@ -155,18 +155,10 @@ func (bs *Backends) Flush() {
 	bs.wg.Add(1)
 	go func() {
 		defer bs.wg.Done()
-		var buf bytes.Buffer
-		err := Compress(&buf, p)
-		if err != nil {
-			log.Printf("write file error: %s\n", err)
-			return
-		}
-
-		p = buf.Bytes()
-
+		
 		// maybe blocked here, run in another goroutine
 		if bs.HttpBackend.IsActive() {
-			err = bs.HttpBackend.WriteCompressed(p)
+			err := bs.HttpBackend.Write(p)
 			switch err {
 			case nil:
 				return
@@ -182,7 +174,7 @@ func (bs *Backends) Flush() {
 			log.Printf("write http error: %s\n", err)
 		}
 
-		err = bs.fb.Write(p)
+		err := bs.fb.Write(p)
 		if err != nil {
 			log.Printf("write file error: %s\n", err)
 		}
@@ -229,7 +221,7 @@ func (bs *Backends) Rewrite() (err error) {
 		return
 	}
 
-	err = bs.HttpBackend.WriteCompressed(p)
+	err = bs.HttpBackend.Write(p)
 
 	switch err {
 	case nil:

--- a/backend/cluster_test.go
+++ b/backend/cluster_test.go
@@ -138,7 +138,7 @@ func TestInfluxdbClusterWrite(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		err := ic.Write(tt.args)
+		err := ic.Write(tt.args, "rp=one_week&precision=s|")
 		if err != nil {
 			t.Error(tt.name, err)
 			continue

--- a/backend/http_test.go
+++ b/backend/http_test.go
@@ -42,7 +42,7 @@ func TestHttpBackendWrite(t *testing.T) {
 	hb := NewHttpBackend(cfg)
 	defer hb.Close()
 
-	err := hb.Write([]byte("cpu,host=server01,region=uswest value=1 1434055562000000000\ncpu value=3,value2=4 1434055562000010000"))
+	err := hb.Write([]byte("rp=one_week&precision=s|cpu,host=server01,region=uswest value=1 1434055562000000000\nrp=one_week&precision=s|cpu value=3,value2=4 1434055562000010000"))
 	if err != nil {
 		t.Errorf("error: %s", err)
 		return

--- a/monitor/metric.go
+++ b/monitor/metric.go
@@ -2,8 +2,8 @@ package monitor
 
 import (
 	"time"
-
-	client "github.com/influxdata/influxdb/client/v2"
+	
+	client "github.com/influxdata/influxdb1-client/v2"
 )
 
 type Metric struct {

--- a/service/http.go
+++ b/service/http.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"strings"
-
+	
 	"github.com/shell909090/influx-proxy/backend"
 )
 
@@ -102,8 +102,13 @@ func (hs *HttpService) HandlerWrite(w http.ResponseWriter, req *http.Request) {
 		w.Write([]byte("method not allow."))
 		return
 	}
+	query := req.URL.Query()
+	db := query.Get("db")
+	rp := query.Get("rp")
+	precision := query.Get("precision")
 
-	db := req.URL.Query().Get("db")
+	// "|"作为分隔符与line进行拼接, 在backend/http.go中进行拆开
+	optionParams := "rp=" + rp + "&precision=" + precision + "|"
 
 	if hs.db != "" {
 		if db != hs.db {
@@ -132,7 +137,7 @@ func (hs *HttpService) HandlerWrite(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	err = hs.ic.Write(p)
+	err = hs.ic.Write(p, optionParams)
 	if err == nil {
 		w.WriteHeader(204)
 	}

--- a/service/main.go
+++ b/service/main.go
@@ -24,6 +24,7 @@ var (
 	ConfigFile  string
 	NodeName    string
 	RedisAddr   string
+	RedisPwd    string
 	LogFilePath string
 )
 
@@ -33,7 +34,8 @@ func init() {
 	flag.StringVar(&LogFilePath, "log-file-path", "/var/log/influx-proxy.log", "output file")
 	flag.StringVar(&ConfigFile, "config", "", "config file")
 	flag.StringVar(&NodeName, "node", "l1", "node name")
-	flag.StringVar(&RedisAddr, "redis", "localhost:6379", "config file")
+	flag.StringVar(&RedisAddr, "redis", "localhost:6379", "redis address")
+	flag.StringVar(&RedisPwd, "redisPwd", "", "redis password")
 	flag.Parse()
 }
 
@@ -88,6 +90,10 @@ func main() {
 
 	if RedisAddr != "" {
 		cfg.Addr = RedisAddr
+	}
+
+	if RedisPwd != "" {
+		cfg.Password = RedisPwd
 	}
 
 	rcs := backend.NewRedisConfigSource(&cfg.Options, cfg.Node)


### PR DESCRIPTION
该RP支持了该issue: #58  

当前的实现思路，是将写参数拼接到每个point前。在发送http post请求前，拆出写参数, 将相同写参数的点进行gzip压缩，再批量发送。

引起的设计变更主要有：
    - 每个点前拼接写参数，引起冗余存储
    - gzip压缩移到了发送http请求前会增加写失败时，本地文件存储的大小。

若有更好的设计思路，欢迎讨论。。